### PR TITLE
Long filename fix

### DIFF
--- a/image_utils.py
+++ b/image_utils.py
@@ -7,7 +7,8 @@ import urllib.request
 import cv2
 import io
 
-img_dir = "imgs"
+IMG_DIR = "imgs"
+MAX_FILENAME_LEN = 128
 
 """
 Adds a user-agent to get around some 403 errors
@@ -40,26 +41,30 @@ def is_img_file(url):
 """
 Attempts to download image from URL
 """
-
-
 def download_img(url):
     if not is_img_file(url):
         raise BadArgument("Invalid URL: not an image")
 
-    if not os.path.exists(img_dir):
-        os.mkdir(img_dir)
-    filename = os.path.join(img_dir, os.path.basename(url))
+    if not os.path.exists(IMG_DIR):
+        os.mkdir(IMG_DIR)
+
+    filename = os.path.basename(url)
+    if len(filename) >= MAX_FILENAME_LEN:
+        filename = "img"
+    img_path = os.path.join(IMG_DIR, filename)
     # create an image extension if one wasn't specified in the URL
-    __, ext = os.path.splitext(filename)
+    __, ext = os.path.splitext(img_path)
     if not ext:
         site = urllib.request.urlopen(url)
         meta = site.info()
         ext = meta["content-type"].split('/')[-1]
-        filename = f"{filename}.{ext}"
+        if len(img_path) >= 128:
+            img_path = "img"
+        img_path = f"{img_path}.{ext}"
 
     # download the image
-    urllib.request.urlretrieve(url, filename)
-    return filename
+    urllib.request.urlretrieve(url, img_path)
+    return img_path
 
 
 """

--- a/main.py
+++ b/main.py
@@ -86,7 +86,6 @@ async def grayscale(ctx, url):
     await image_utils.send_img_by_mat(ctx, img, "grayscale.jpg")
     image_utils.delete_img(img_path)
 
-
 @grayscale.error
 async def grayscale_error_handler(ctx, error):
     if isinstance(error, commands.MissingRequiredArgument):

--- a/tests/image_links.md
+++ b/tests/image_links.md
@@ -27,3 +27,7 @@ Send these commands to the bot to test image link processing
 7. Image that requires a user-agent to be set
     * `$test_image https://cdn.discordapp.com/attachments/882807640080674866/1072234438144037094/20230206_141622.jpg`
     * A stack of crewmate action figures (should not be a 403 error)
+
+8. Image with long filename
+    * `$test_image https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.survivethenews.com%2Fwp-content%2Fuploads%2F2022%2F08%2F1659378236_411_Reuters-Runs-Cover-for-Dementia-Joe-and-%25E2%2580%2598Fact-Checks-Funny-Meme.jpg&f=1&nofb=1&ipt=402b35a33f341c13a4c8c4b8553448c15f6296581479667007462ce2e6471a09&ipo=images`
+    * Joe Biden eating ice cream


### PR DESCRIPTION
**Fixes**
* Issue where images with especially long URLs would cause `OSError`'s complaining about long filenames